### PR TITLE
fix: package.json format and dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,12 +3,13 @@
   "category": "Svelto",
   "description": "Svelto common utilities and datastructures",
   "dependencies": {
-    "com.unity.collections": "0.3.0",
+    "com.unity.collections": "0.1.1-preview"
   },
   "keywords": [
-    "svelto",
+    "svelto"
   ],
   "name": "com.sebaslab.svelto.common",
   "unity": "2019.2",
-  "version": "2.9"
+  "version": "2.9.1",
+  "type": "library"
 }


### PR DESCRIPTION
Part of https://github.com/sebas77/Svelto.ECS/issues/45
- correct the json format (last comma issue)
- fix the dependency com.unity.collections 0.3.0 => 0.1.1-preview. v0.3.0 seems does not exist? using latest version 0.1.1-preview instead